### PR TITLE
CP-425: SPIKE: Having multiple config files in one config repo

### DIFF
--- a/config.strict.js
+++ b/config.strict.js
@@ -1,0 +1,25 @@
+module.exports = {
+  extends: [
+    "eslint-config-airbnb-base",
+    "eslint:recommended",
+    "prettier",
+    "plugin:sonarjs/recommended",
+    "plugin:import/errors",
+    "plugin:import/warnings",
+    "plugin:jest/recommended",
+    "plugin:unicorn/recommended",
+    "plugin:node/recommended",
+  ],
+  plugins: [
+    "import",
+    "json",
+    "import",
+    "jest",
+    "prettier",
+    "simple-import-sort",
+    "sonarjs",
+    "sort-destructure-keys",
+    "unicorn",
+    "node",
+  ],
+};

--- a/config.ts.js
+++ b/config.ts.js
@@ -1,0 +1,35 @@
+module.exports = {
+  extends: ["eslint-config-airbnb-base", "eslint:recommended", "prettier"],
+  plugins: [
+    "import",
+    "json",
+    "import",
+    "jest",
+    "prettier",
+    "simple-import-sort",
+    "sonarjs",
+    "sort-destructure-keys",
+    "unicorn",
+    "node",
+  ],
+  rules: {
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: "module",
+      ecmaFeatures: {
+        modules: true,
+      },
+    },
+    rules: {
+      "import/default": "off",
+      "import/named": "off",
+      "import/namespace": "off",
+      "import/no-default-export": "error",
+      "import/prefer-default-export": "off",
+      "prettier/prettier": "error",
+      "simple-import-sort/imports": "error",
+      "simple-import-sort/exports": "error",
+      "sort-destructure-keys/sort-destructure-keys": "error",
+    },
+  },
+};


### PR DESCRIPTION

**Description**

Idea:  
rather than having only one index.js file, try to use several  
[https://github.com/open-turo/eslint-config-typescript/blob/main/index.js](https://github.com/open-turo/eslint-config-typescript/blob/main/index.js "smart-link")

config-repo.git

/config.js
/config.ts.js
/config.ts.react.js
etc...

to try

[https://github.com/turo/typescript-template/blob/main/.eslintrc](https://github.com/turo/typescript-template/blob/main/.eslintrc "smart-link")  
{{ "extends": \["@open-turo/eslint-config-typescript/some-file.js"\]}} ???

Fixes [#CP-425](https://team-turo.atlassian.net/browse/CP-425)

**Changes**

* feat: adding exp files

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
